### PR TITLE
I14 service layer

### DIFF
--- a/lib/service/ufind_queries.dart
+++ b/lib/service/ufind_queries.dart
@@ -1,7 +1,6 @@
 /// Fluent API implementation to specify the query arguments to be used
 /// when searching for entities exposed by u:find
 
-
 /// The base class for all query arguments
 /// [asString] must be implemented by all subclasses.
 abstract class QueryArgument {
@@ -10,16 +9,23 @@ abstract class QueryArgument {
   /// Renders this [QueryArgument] as a [String] that can be used
   /// in the http query parameter.
   String asString();
+
+  /// Joins a specified [searchKeyword] and a list of [QueryArgument] instances
+  /// into a single [String] that can be directly used in the http query parameter.
+  static String toQueryString(String searchKeyword, List<QueryArgument> args) {
+    final joinedArgs = args.map((e) => e.asString()).join(' ');
+    return '$searchKeyword $joinedArgs';
+  }
 }
 
 /// The base class for all query arguments
 /// that can be used for general result filtering
-abstract class FilterQueryArgument extends QueryArgument {
-  const FilterQueryArgument();
+abstract class GeneralQueryArgument extends QueryArgument {
+  const GeneralQueryArgument();
 }
 
 /// Set the number of search results
-class Count extends FilterQueryArgument {
+class Count extends GeneralQueryArgument {
   final int numSearchResults;
 
   Count(this.numSearchResults);
@@ -29,9 +35,9 @@ class Count extends FilterQueryArgument {
 }
 
 /// Exact, non-fuzzy search
-const FilterQueryArgument Exact = _Exact();
+const GeneralQueryArgument Exact = _Exact();
 
-class _Exact extends FilterQueryArgument {
+class _Exact extends GeneralQueryArgument {
   const _Exact();
 
   @override

--- a/lib/service/ufind_queries.dart
+++ b/lib/service/ufind_queries.dart
@@ -1,0 +1,126 @@
+/// Fluent API implementation to specify the query arguments to be used
+/// when searching for entities exposed by u:find
+
+
+/// The base class for all query arguments
+/// [asString] must be implemented by all subclasses.
+abstract class QueryArgument {
+  const QueryArgument();
+
+  /// Renders this [QueryArgument] as a [String] that can be used
+  /// in the http query parameter.
+  String asString();
+}
+
+/// The base class for all query arguments
+/// that can be used for general result filtering
+abstract class FilterQueryArgument extends QueryArgument {
+  const FilterQueryArgument();
+}
+
+/// Set the number of search results
+class Count extends FilterQueryArgument {
+  final int numSearchResults;
+
+  Count(this.numSearchResults);
+
+  @override
+  String asString() => 'c:$numSearchResults';
+}
+
+/// Exact, non-fuzzy search
+const FilterQueryArgument Exact = _Exact();
+
+class _Exact extends FilterQueryArgument {
+  const _Exact();
+
+  @override
+  String asString() => '+exact';
+}
+
+/// The base class for all query arguments
+/// that can be used when searching for courses
+abstract class CourseQueryArgument extends QueryArgument {
+  const CourseQueryArgument();
+}
+
+/// Filter for courses with streaming
+const OffersUStream = _OffersUStream();
+
+class _OffersUStream extends CourseQueryArgument {
+  const _OffersUStream();
+
+  @override
+  String asString() => 'ustream';
+}
+
+/// Search for courses of a certain directorate of studies
+class SPL extends CourseQueryArgument {
+  final int splNum;
+
+  SPL(this.splNum);
+
+  @override
+  String asString() => 'spl$splNum';
+}
+
+/// Search for courses in a certain semester
+class InSemester extends CourseQueryArgument {
+  final String semester;
+
+  InSemester(this.semester);
+
+  @override
+  String asString() => '$semester';
+}
+
+/// Search for courses in certain semesters
+class SemesterRange extends CourseQueryArgument {
+  final String startSemester;
+  final String endSemester;
+
+  SemesterRange(this.startSemester, this.endSemester);
+
+  @override
+  String asString() => '$startSemester-$endSemester';
+}
+
+/// Search for courses in the current semester
+const CurrentTerm = _CurrentTerm();
+
+class _CurrentTerm extends CourseQueryArgument {
+  const _CurrentTerm();
+
+  @override
+  String asString() => '+currentterm';
+}
+
+/// Search for courses in the current study year
+const CurrentYear = _CurrentYear();
+
+class _CurrentYear extends CourseQueryArgument {
+  const _CurrentYear();
+
+  @override
+  String asString() => '+currentyear';
+}
+
+/// Sort search results alphabetically
+const SortAlphabetically = _SortAlphabetically();
+
+class _SortAlphabetically extends CourseQueryArgument {
+  const _SortAlphabetically();
+
+  @override
+  String asString() => '+sort';
+}
+
+/// Sort courses by course number
+const SortByCourseNumber = _SortByCourseNumber();
+
+class _SortByCourseNumber extends CourseQueryArgument {
+  const _SortByCourseNumber();
+
+  @override
+  String asString() => '+sortnumber';
+}

--- a/lib/service/ufind_service.dart
+++ b/lib/service/ufind_service.dart
@@ -9,6 +9,7 @@ const authority = "m1-ufind.univie.ac.at";
 
 /// Returns the root [StudyModule] based on the specified semester [when]
 /// and the [spl].
+///
 /// Calling [fetchStudyModule('2021S', 5)] would return the root [StudyModule]
 /// of the Computer Science faculty of the summer semester 2021.
 /// Upon providing a [when] value that is in the future, such as 2030S,

--- a/lib/service/ufind_service.dart
+++ b/lib/service/ufind_service.dart
@@ -23,3 +23,17 @@ Future<StudyModule?> fetchStudyModule(String when, int spl) {
     return root.mapDescendant('module', (e) => StudyModule.fromXmlTag(e));
   });
 }
+
+/// Returns a list of [Course] objects that satisfy the specified [query].
+///
+/// The [query] needs to be composed as it is described at https://ufind.univie.ac.at/en/help.html.
+Future<List<Course>> fetchCourses(String query) {
+  final url = Uri.https(authority, 'courses', {'query': query});
+  return http.get(url).then((response) {
+    if (response.statusCode != 200)
+      throw new HttpException(
+          'Unexpected response status code: ${response.statusCode}');
+    final root = response.body.toXmlElement();
+    return root.mapDescendants('course', (e) => Course.fromXmlTag(e));
+  });
+}

--- a/lib/service/ufind_service.dart
+++ b/lib/service/ufind_service.dart
@@ -4,6 +4,7 @@ import 'package:http/http.dart' as http;
 import 'package:we_find/extensions/string_extensions.dart';
 import 'package:we_find/extensions/xml_extensions.dart';
 import 'package:we_find/model/model.dart';
+import 'package:we_find/service/ufind_queries.dart';
 
 const authority = "m1-ufind.univie.ac.at";
 
@@ -38,4 +39,13 @@ Future<List<Course>> fetchCourses(String query) {
     final root = response.body.toXmlElement();
     return root.mapDescendants('course', (e) => Course.fromXmlTag(e));
   });
+}
+
+const defaultQueryArg = CurrentTerm;
+
+/// Convenience method to query for courses.
+Future<List<Course>> queryForCourses(String searchKeyword,
+    {QueryArgument queryArg = defaultQueryArg}) {
+  final queryString = '$searchKeyword ${queryArg.asString()}';
+  return fetchCourses(queryString);
 }

--- a/lib/service/ufind_service.dart
+++ b/lib/service/ufind_service.dart
@@ -26,7 +26,8 @@ Future<StudyModule?> fetchStudyModule(String when, int spl) {
 
 /// Returns a list of [Course] objects that satisfy the specified [query].
 ///
-/// The [query] needs to be composed as it is described at https://ufind.univie.ac.at/en/help.html.
+/// The [query] needs to be composed as it is described
+/// at https://ufind.univie.ac.at/en/help.html.
 Future<List<Course>> fetchCourses(String query) {
   final url = Uri.https(authority, 'courses', {'query': query});
   return http.get(url).then((response) {

--- a/lib/service/ufind_service.dart
+++ b/lib/service/ufind_service.dart
@@ -1,0 +1,25 @@
+import 'dart:io';
+
+import 'package:http/http.dart' as http;
+import 'package:we_find/extensions/string_extensions.dart';
+import 'package:we_find/extensions/xml_extensions.dart';
+import 'package:we_find/model/model.dart';
+
+const authority = "m1-ufind.univie.ac.at";
+
+/// Returns the root [StudyModule] based on the specified semester [when]
+/// and the [spl].
+/// Calling [fetchStudyModule('2021S', 5)] would return the root [StudyModule]
+/// of the Computer Science faculty of the summer semester 2021.
+/// Upon providing a [when] value that is in the future, such as 2030S,
+/// the request will be successful, however the returned [StudyModule] will be null.
+Future<StudyModule?> fetchStudyModule(String when, int spl) {
+  final url = Uri.https(authority, 'courses/browse/$when/$spl');
+  return http.get(url).then((response) {
+    if (response.statusCode != 200)
+      throw new HttpException(
+          'Unexpected response status code: ${response.statusCode}');
+    final root = response.body.toXmlElement();
+    return root.mapDescendant('module', (e) => StudyModule.fromXmlTag(e));
+  });
+}

--- a/macos/Podfile.lock
+++ b/macos/Podfile.lock
@@ -1,0 +1,22 @@
+PODS:
+  - FlutterMacOS (1.0.0)
+  - wakelock_macos (0.0.1):
+    - FlutterMacOS
+
+DEPENDENCIES:
+  - FlutterMacOS (from `Flutter/ephemeral`)
+  - wakelock_macos (from `Flutter/ephemeral/.symlinks/plugins/wakelock_macos/macos`)
+
+EXTERNAL SOURCES:
+  FlutterMacOS:
+    :path: Flutter/ephemeral
+  wakelock_macos:
+    :path: Flutter/ephemeral/.symlinks/plugins/wakelock_macos/macos
+
+SPEC CHECKSUMS:
+  FlutterMacOS: 57701585bf7de1b3fc2bb61f6378d73bbdea8424
+  wakelock_macos: be77ee763536aa7f0b38d7d892aa2e02bd7fcd5f
+
+PODFILE CHECKSUM: 6eac6b3292e5142cfc23bdeb71848a40ec51c14c
+
+COCOAPODS: 1.10.1

--- a/macos/Runner.xcodeproj/project.pbxproj
+++ b/macos/Runner.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		33CC10F32044A3C60003C045 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 33CC10F22044A3C60003C045 /* Assets.xcassets */; };
 		33CC10F62044A3C60003C045 /* MainMenu.xib in Resources */ = {isa = PBXBuildFile; fileRef = 33CC10F42044A3C60003C045 /* MainMenu.xib */; };
 		33CC11132044BFA00003C045 /* MainFlutterWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33CC11122044BFA00003C045 /* MainFlutterWindow.swift */; };
+		8BB800AE5F468D5489BB761F /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9530689FD407882A2A21B9C9 /* Pods_Runner.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -52,9 +53,10 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		24B06E3FE9E09D7E2084541E /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
 		333000ED22D3DE5D00554162 /* Warnings.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Warnings.xcconfig; sourceTree = "<group>"; };
 		335BBD1A22A9A15E00E9071D /* GeneratedPluginRegistrant.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GeneratedPluginRegistrant.swift; sourceTree = "<group>"; };
-		33CC10ED2044A3C60003C045 /* we_find.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "we_find.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		33CC10ED2044A3C60003C045 /* we_find.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = we_find.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		33CC10F02044A3C60003C045 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		33CC10F22044A3C60003C045 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Assets.xcassets; path = Runner/Assets.xcassets; sourceTree = "<group>"; };
 		33CC10F52044A3C60003C045 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/MainMenu.xib; sourceTree = "<group>"; };
@@ -67,7 +69,10 @@
 		33E51914231749380026EE4D /* Release.entitlements */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.entitlements; path = Release.entitlements; sourceTree = "<group>"; };
 		33E5194F232828860026EE4D /* AppInfo.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = AppInfo.xcconfig; sourceTree = "<group>"; };
 		7AFA3C8E1D35360C0083082E /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Release.xcconfig; sourceTree = "<group>"; };
+		7E85E57BFDB0BD7E19DD2AC3 /* Pods-Runner.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.profile.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.profile.xcconfig"; sourceTree = "<group>"; };
+		9530689FD407882A2A21B9C9 /* Pods_Runner.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Runner.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		9740EEB21CF90195004384FC /* Debug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Debug.xcconfig; sourceTree = "<group>"; };
+		B5977B4194A4CAD4CA1D2EA1 /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -75,6 +80,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				8BB800AE5F468D5489BB761F /* Pods_Runner.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -99,6 +105,7 @@
 				33CEB47122A05771004F2AC0 /* Flutter */,
 				33CC10EE2044A3C60003C045 /* Products */,
 				D73912EC22F37F3D000D13A0 /* Frameworks */,
+				E5AAF3FAC0240766C06A761B /* Pods */,
 			);
 			sourceTree = "<group>";
 		};
@@ -148,8 +155,20 @@
 		D73912EC22F37F3D000D13A0 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				9530689FD407882A2A21B9C9 /* Pods_Runner.framework */,
 			);
 			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		E5AAF3FAC0240766C06A761B /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				24B06E3FE9E09D7E2084541E /* Pods-Runner.debug.xcconfig */,
+				B5977B4194A4CAD4CA1D2EA1 /* Pods-Runner.release.xcconfig */,
+				7E85E57BFDB0BD7E19DD2AC3 /* Pods-Runner.profile.xcconfig */,
+			);
+			name = Pods;
+			path = Pods;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -159,11 +178,13 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 33CC10FB2044A3C60003C045 /* Build configuration list for PBXNativeTarget "Runner" */;
 			buildPhases = (
+				3A79CA300B237CE9FBA38D10 /* [CP] Check Pods Manifest.lock */,
 				33CC10E92044A3C60003C045 /* Sources */,
 				33CC10EA2044A3C60003C045 /* Frameworks */,
 				33CC10EB2044A3C60003C045 /* Resources */,
 				33CC110E2044A8840003C045 /* Bundle Framework */,
 				3399D490228B24CF009A79C7 /* ShellScript */,
+				39E6BA84C8260F48A2DCD462 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -269,6 +290,45 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "\"$FLUTTER_ROOT\"/packages/flutter_tools/bin/macos_assemble.sh && touch Flutter/ephemeral/tripwire";
+		};
+		39E6BA84C8260F48A2DCD462 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		3A79CA300B237CE9FBA38D10 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-Runner-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/macos/Runner.xcworkspace/contents.xcworkspacedata
+++ b/macos/Runner.xcworkspace/contents.xcworkspacedata
@@ -4,4 +4,7 @@
    <FileRef
       location = "group:Runner.xcodeproj">
    </FileRef>
+   <FileRef
+      location = "group:Pods/Pods.xcodeproj">
+   </FileRef>
 </Workspace>

--- a/test/base_matchers.dart
+++ b/test/base_matchers.dart
@@ -1,0 +1,7 @@
+import 'package:flutter_test/flutter_test.dart';
+
+class IterableLength extends CustomMatcher {
+  IterableLength(matcher) : super('Number of items', 'length', matcher);
+
+  featureValueOf(actual) => (actual as Iterable).length;
+}

--- a/test/model/model_test.dart
+++ b/test/model/model_test.dart
@@ -2,6 +2,7 @@ import 'package:test/test.dart';
 import 'package:we_find/extensions/string_extensions.dart';
 import 'package:we_find/model/model.dart';
 
+import '../base_matchers.dart';
 import 'model_matchers.dart';
 
 void main() {
@@ -190,7 +191,7 @@ void main() {
       expect(obj.vorbesprechung, isNotNull,
           reason: 'vorbesprechung should not be null');
       expect(obj.locations, isNotNull, reason: 'locations should not be null');
-      expect(obj.locations!.length, equals(3),
+      expect(obj.locations!, IterableLength(equals(3)),
           reason: 'locations should have a length of 3');
     });
   });
@@ -218,7 +219,7 @@ void main() {
         "the events list should have a length of 1", () {
       final obj = Schedule.fromXmlTag(fullTag);
       expect(obj.text, isNull, reason: 'text should be null');
-      expect(obj.events.length, equals(1),
+      expect(obj.events, IterableLength(equals(1)),
           reason: 'events should have a length of 3');
     });
   });
@@ -331,15 +332,15 @@ void main() {
       expect(obj.title, isNotNull, reason: 'title should not be null');
       expect(obj.when, isNotNull, reason: 'when should not be null');
       expect(obj.schedule, isNotNull, reason: 'schedule should not be null');
-      expect(obj.schedule!.events.length, equals(1),
+      expect(obj.schedule!.events, IterableLength(equals(1)),
           reason: 'schedule.events should have a length of 1');
       expect(obj.examiners, isNotNull, reason: 'examiners should not be null');
-      expect(obj.examiners!.length, equals(2),
+      expect(obj.examiners!, IterableLength(equals(2)),
           reason: 'examiners should have a length of 2');
       expect(obj.registrations, isNotNull,
           reason: 'registrations should not be null');
       expect(obj.labels, isNotNull, reason: 'labels should not be null');
-      expect(obj.labels!.length, equals(1),
+      expect(obj.labels!, IterableLength(equals(1)),
           reason: 'labels should have a length of 1');
       expect(obj.generalInformation, isNotNull,
           reason: 'generalInformation should not be null');
@@ -534,23 +535,23 @@ void main() {
       expect(obj.maxParticipants, isNotNull,
           reason: 'maxParticipants should not be null');
       expect(obj.languages, isNotNull, reason: 'languages should not be null');
-      expect(obj.languages!.length, equals(1),
+      expect(obj.languages!, IterableLength(equals(1)),
           reason: 'languages should have a length of 1');
       expect(obj.schedule, isNotNull, reason: 'schedule should not be null');
-      expect(obj.schedule!.events.length, equals(3),
+      expect(obj.schedule!.events, IterableLength(equals(3)),
           reason: 'schedule.events should have a length of 3');
       expect(obj.lecturers, isNotNull, reason: 'lecturers should not be null');
-      expect(obj.lecturers!.length, equals(2),
+      expect(obj.lecturers!, IterableLength(equals(2)),
           reason: 'lecturers should have a length of 2');
       expect(obj.registrations, isNotNull,
           reason: 'registrations should not be null');
       expect(obj.info, isNotNull,
           reason: 'generalInformation should not be null');
       expect(obj.exams, isNotNull, reason: 'exams should not be null');
-      expect(obj.exams!.length, equals(2),
+      expect(obj.exams!, IterableLength(equals(2)),
           reason: 'exams should have a length of 2');
       expect(obj.labels, isNotNull, reason: 'labels should not be null');
-      expect(obj.labels!.length, equals(1),
+      expect(obj.labels!, IterableLength(equals(1)),
           reason: 'labels should have a length of 1');
     });
   });
@@ -650,10 +651,10 @@ void main() {
       expect(obj.sws, isNotNull, reason: 'sws should not be null');
       expect(obj.immanent, isNotNull, reason: 'immanent should not be null');
       expect(obj.chapters, isNotNull, reason: 'chapters should not be null');
-      expect(obj.chapters!.length, equals(2),
+      expect(obj.chapters!, IterableLength(equals(2)),
           reason: 'chapters should have a length of 2');
       expect(obj.groups, isNotNull, reason: 'groups should not be null');
-      expect(obj.groups!.length, equals(1),
+      expect(obj.groups!, IterableLength(equals(1)),
           reason: 'groups should have a length of 1');
       expect(obj.offeredBy, isNotNull,
           reason: 'courseOfferee should not be null');
@@ -986,7 +987,7 @@ void main() {
       expect(obj.nestLevel, isNotNull, reason: 'nestLevel should not be null');
       expect(obj.spl, isNotNull, reason: 'spl should not be null');
       expect(obj.path, isNotNull, reason: 'path should not be null');
-      expect(obj.path?.length, equals(2),
+      expect(obj.path!, IterableLength(equals(2)),
           reason: 'path should have a length of 2');
       expect(obj.when, isNotNull, reason: 'when should not be null');
       expect(obj.anchor, isNotNull, reason: 'anchor should not be null');
@@ -998,14 +999,14 @@ void main() {
       expect(obj.title, isNotNull, reason: 'title should not be null');
       expect(obj.comment, isNotNull, reason: 'comment should not be null');
       expect(obj.courses, isNotNull, reason: 'courses should not be null');
-      expect(obj.courses?.length, equals(0),
+      expect(obj.courses!, IterableLength(equals(0)),
           reason: 'courses should have a length of 2');
       expect(obj.exams, isNotNull, reason: 'exams should not be null');
-      expect(obj.exams?.length, equals(0),
+      expect(obj.exams!, IterableLength(equals(0)),
           reason: 'exams should have a length of 2');
       expect(obj.submodules, isNotNull,
           reason: 'submodules should not be null');
-      expect(obj.submodules?.length, equals(18),
+      expect(obj.submodules!, IterableLength(equals(18)),
           reason: 'submodules should have a length of 18');
     });
   });

--- a/test/service/ufind_service_test.dart
+++ b/test/service/ufind_service_test.dart
@@ -1,0 +1,33 @@
+import 'dart:io';
+
+import 'package:test/test.dart';
+import 'package:we_find/service/ufind_service.dart';
+
+void main() {
+  group('fetchStudyModule', () {
+    test(
+        'When entering valid arguments then the value returned from the Future '
+        'should not be null', () {
+      final validWhen = '2021S';
+      final validSpl = 5;
+      final studyModuleFuture = fetchStudyModule(validWhen, validSpl);
+      expect(studyModuleFuture, completion(isNotNull));
+    });
+    test(
+        'When entering a future semester value and a valid spl then the value '
+        'returned from the Future should be null', () {
+      final futureWhen = '2030S';
+      final validSpl = 5;
+      final studyModuleFuture = fetchStudyModule(futureWhen, validSpl);
+      expect(studyModuleFuture, completion(isNull));
+    });
+    test(
+        'When entering an invalid semester value and an invalid spl then '
+        'an HttpException should be thrown', () {
+      final invalidWhen = '2021lol';
+      final invalid = -3;
+      final studyModuleFuture = fetchStudyModule(invalidWhen, invalid);
+      expect(studyModuleFuture, throwsA(const TypeMatcher<HttpException>()));
+    });
+  });
+}

--- a/test/service/ufind_service_test.dart
+++ b/test/service/ufind_service_test.dart
@@ -41,5 +41,11 @@ void main() {
       final coursesFuture = fetchCourses(query);
       expect(coursesFuture, completion(IterableLength(equals(10))));
     });
+
+    test('When entering a nonsense query an empty list should be returned', () {
+      final query = 'AaEFdfq2e';
+      final coursesFuture = fetchCourses(query);
+      expect(coursesFuture, completion(IterableLength(equals(0))));
+    });
   });
 }

--- a/test/service/ufind_service_test.dart
+++ b/test/service/ufind_service_test.dart
@@ -3,6 +3,8 @@ import 'dart:io';
 import 'package:test/test.dart';
 import 'package:we_find/service/ufind_service.dart';
 
+import '../base_matchers.dart';
+
 void main() {
   group('fetchStudyModule', () {
     test(
@@ -28,6 +30,16 @@ void main() {
       final invalid = -3;
       final studyModuleFuture = fetchStudyModule(invalidWhen, invalid);
       expect(studyModuleFuture, throwsA(const TypeMatcher<HttpException>()));
+    });
+  });
+
+  group('fetchCourses', () {
+    test(
+        'When entering a legal query for 10 courses, a list of 10 Course '
+        'objects should be returned from the Future', () {
+      final query = 'spl5 c:10';
+      final coursesFuture = fetchCourses(query);
+      expect(coursesFuture, completion(IterableLength(equals(10))));
     });
   });
 }

--- a/test/service/ufind_service_test.dart
+++ b/test/service/ufind_service_test.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 
 import 'package:test/test.dart';
+import 'package:we_find/service/ufind_queries.dart';
 import 'package:we_find/service/ufind_service.dart';
 
 import '../base_matchers.dart';
@@ -46,6 +47,14 @@ void main() {
       final query = 'AaEFdfq2e';
       final coursesFuture = fetchCourses(query);
       expect(coursesFuture, completion(IterableLength(equals(0))));
+    });
+  });
+
+  group('queryForCourses', () {
+    test('When querying for courses with a count argument of 42, '
+        '42 results should be returned', () {
+      final coursesFuture = queryForCourses('math', queryArg: Count(42));
+      expect(coursesFuture, completion(IterableLength(equals(42))));
     });
   });
 }


### PR DESCRIPTION
Implements #14.

To handle the different query arguments in a generic way, I introduced an abstract class-based approach in [ufind_queries.dart](https://github.com/memoriesadrift/we-find/blob/i14-service-layer/lib/service/ufind_queries.dart). It makes it possible to access the different query options through the same interface and at the same time it is very easy to add support for further query options in the future.

Currently the following options are implemented:
- Set the number of search results
- Exact, non-fuzzy search
- Filter for courses with streaming
- Search for courses of a certain directorate of studies
- Search for courses in certain semesters
- Search for courses in the current semester
- Search for courses in the current study year
- Sort search results alphabetically
- Sort courses by course number

The implementation is fully compliant with the specifications of the [u:find help page](https://ufind.univie.ac.at/en/help.html)

Unfortunately, it seems like the API does not support chaining multiple query arguments. This seems pretty unrealistic though and I hope that I am only missing something very obvious. For the former case, the function [queryForCourses](https://github.com/memoriesadrift/we-find/blob/i14-service-layer/lib/service/ufind_queries.dart#L47) supports only one `QueryArgument`. If it turns out that the latter case is true, the code can be easily modified to handle chained arguments.