### PR TITLE
I25 i18n support

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,15 +1,33 @@
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:we_find/providers/fav_course_provider.dart';
+import 'package:we_find/providers/lang_provider.dart';
 import 'package:we_find/screens/HomeScreen.dart';
 import 'package:we_find/styles/theme.dart' as Theme;
 
-void main() => runApp(WeFindApp());
+void main() => runApp(appProvider(WeFindApp()));
+
+/// Wraps the supplied [appRoot] into a [MultiProvider] that gives access to
+/// all the shared states for the Widget-tree.
+MultiProvider appProvider(Widget appRoot) => MultiProvider(
+      providers: [
+        ChangeNotifierProvider<FavCourseProvider>(
+          create: (_) => FavCourseProvider(),
+        ),
+        ChangeNotifierProvider<LangProvider>(
+          create: (_) => LangProvider(),
+        )
+      ],
+      child: appRoot,
+    );
 
 class WeFindApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
-        title: 'we:find',
-        theme: Theme.lightThemeData,
-        home: HomeScreen());
+      title: 'we:find',
+      theme: Theme.lightThemeData,
+      home: HomeScreen(),
+    );
   }
 }

--- a/lib/screens/CourseDetailScreen.dart
+++ b/lib/screens/CourseDetailScreen.dart
@@ -6,7 +6,9 @@ class CourseDetailScreen extends StatelessWidget {
   final CourseWrapped _course;
   const CourseDetailScreen(this._course);
 
-  ListView _buildCourseDetailScreen(ThemeData themeData) {
+  ListView _buildCourseDetailScreen(BuildContext context) {
+    final ThemeData themeData = Theme.of(context);
+
     List<Widget> view = [];
 
     // Title
@@ -32,11 +34,10 @@ class CourseDetailScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final ThemeData themeData = Theme.of(context);
     return Container(
       margin: const EdgeInsets.all(15),
       padding: const EdgeInsets.all(15),
-      child: _buildCourseDetailScreen(themeData),
+      child: _buildCourseDetailScreen(context),
     );
   }
 }

--- a/lib/screens/CourseDirectoryScreen.dart
+++ b/lib/screens/CourseDirectoryScreen.dart
@@ -18,7 +18,9 @@ class _CourseDirecotryScreenState extends State<CourseDirecotryScreen> {
     return name;
   }
 
-  ListView _buildStudyModuleScreen(ThemeData themeData) {
+  ListView _buildStudyModuleScreen(BuildContext context) {
+    final ThemeData themeData = Theme.of(context);
+
     List<Widget> view = [];
 
     view.add(Text(
@@ -42,13 +44,12 @@ class _CourseDirecotryScreenState extends State<CourseDirecotryScreen> {
 
   @override
   Widget build(BuildContext context) {
-    final ThemeData themeData = Theme.of(context);
     return Scrollbar(
       isAlwaysShown: true,
       child: Container(
         margin: const EdgeInsets.all(15),
         padding: const EdgeInsets.all(15),
-        child: _buildStudyModuleScreen(themeData),
+        child: _buildStudyModuleScreen(context),
       ),
     );
   }

--- a/lib/screens/HomeScreen.dart
+++ b/lib/screens/HomeScreen.dart
@@ -1,18 +1,18 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:we_find/data/course.dart';
 import 'package:we_find/data/coursedir.dart';
-import 'package:we_find/model/I18NString.dart';
 import 'package:we_find/model/model.dart';
 import 'package:we_find/model/modelWrapped.dart';
+import 'package:we_find/providers/lang_provider.dart';
 import 'package:we_find/screens/CourseDetailScreen.dart';
 import 'package:we_find/screens/CourseDirectoryScreen.dart';
 import 'package:we_find/screens/SearchResultsScreen.dart';
 import 'package:we_find/service/ufind_service.dart';
 import 'package:we_find/widgets/search_bar.dart';
-
 import 'package:xml/xml.dart';
-import 'package:we_find/data/course.dart';
 
 class HomeScreen extends StatelessWidget {
   // REMOVE NEXT THREE METHODS ONCE PASSING DATA ACTUALLY WORKS
@@ -37,6 +37,9 @@ class HomeScreen extends StatelessWidget {
   Widget build(BuildContext context) {
     const String WEFIND_TITLE = 'we:find';
     final ThemeData themeData = Theme.of(context);
+    final langProvider = Provider.of<LangProvider>(context);
+    final currentLang = langProvider.currentLang;
+
     return Scaffold(
       body: Column(
         children: [
@@ -70,7 +73,8 @@ class HomeScreen extends StatelessWidget {
                               return CircularProgressIndicator();
                             }
                             if (snapshot.data != null) {
-                              return SerchResultsScreen(snapshot.data!, input);
+                              return SearchResultsScreen(
+                                  context, snapshot.data!, input);
                             }
                             throw Exception("don't you dare throw this!");
                           },
@@ -109,7 +113,7 @@ class HomeScreen extends StatelessWidget {
                                   return CourseDirecotryScreen(
                                       StudyModuleWrapped(
                                     snapshot.data!,
-                                    Lang.DE,
+                                    currentLang,
                                   ));
                                 }
                                 throw Exception("don't you dare throw this!");
@@ -174,7 +178,7 @@ class HomeScreen extends StatelessWidget {
                           }
                           if (snapshot.data != null) {
                             return CourseDetailScreen(
-                                CourseWrapped(snapshot.data!, Lang.DE));
+                                CourseWrapped(snapshot.data!, currentLang));
                           }
                           throw Exception("don't you dare throw this!");
                         },

--- a/lib/screens/SearchResultsScreen.dart
+++ b/lib/screens/SearchResultsScreen.dart
@@ -14,7 +14,9 @@ class SerchResultsScreen extends StatelessWidget {
     }
   }
 
-  ListView _buildSearchResults(ThemeData themeData) {
+  ListView _buildSearchResults(BuildContext context) {
+    final ThemeData themeData = Theme.of(context);
+
     List<Widget> view = [];
 
     view.add(Text(
@@ -34,13 +36,11 @@ class SerchResultsScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final ThemeData themeData = Theme.of(context);
-
     return Container(
       margin: const EdgeInsets.all(15),
       padding: const EdgeInsets.all(15),
       child: Scrollbar(
-        child: _buildSearchResults(themeData),
+        child: _buildSearchResults(context),
       ),
     );
   }

--- a/lib/screens/SearchResultsScreen.dart
+++ b/lib/screens/SearchResultsScreen.dart
@@ -1,16 +1,21 @@
 import 'package:flutter/material.dart';
-import 'package:we_find/model/I18NString.dart';
+import 'package:provider/provider.dart';
 import 'package:we_find/model/model.dart';
 import 'package:we_find/model/modelWrapped.dart';
+import 'package:we_find/providers/lang_provider.dart';
 import 'package:we_find/widgets/CourseWidget.dart';
 
-class SerchResultsScreen extends StatelessWidget {
+class SearchResultsScreen extends StatelessWidget {
+  final BuildContext _context;
   final List<CourseWrapped> _myCourses = [];
   final String _searchQuery;
-  SerchResultsScreen(List<Course> courses, this._searchQuery) {
+
+  SearchResultsScreen(this._context, List<Course> courses, this._searchQuery) {
+    final langProvider = Provider.of<LangProvider>(_context);
+    final currentLang = langProvider.currentLang;
     for (Course eachCourse in courses) {
       // TODO: CHANGE THE LANGUAGE TO SOMETHING MEANINGFULL!
-      _myCourses.add(CourseWrapped(eachCourse, Lang.DE));
+      _myCourses.add(CourseWrapped(eachCourse, currentLang));
     }
   }
 

--- a/lib/screens/StudyModuleScreen.dart
+++ b/lib/screens/StudyModuleScreen.dart
@@ -18,7 +18,9 @@ class _StudyModuleScreenState extends State<StudyModuleScreen> {
     return name;
   }
 
-  ListView _buildStudyModuleScreen(ThemeData themeData) {
+  ListView _buildStudyModuleScreen(BuildContext context) {
+    final ThemeData themeData = Theme.of(context);
+
     List<Widget> view = [];
 
     view.add(Text(
@@ -42,12 +44,11 @@ class _StudyModuleScreenState extends State<StudyModuleScreen> {
 
   @override
   Widget build(BuildContext context) {
-    final ThemeData themeData = Theme.of(context);
     return Scrollbar(
       child: Container(
         margin: const EdgeInsets.all(15),
         padding: const EdgeInsets.all(15),
-        child: _buildStudyModuleScreen(themeData),
+        child: _buildStudyModuleScreen(context),
       ),
     );
   }

--- a/lib/widgets/course_detail_widgets.dart
+++ b/lib/widgets/course_detail_widgets.dart
@@ -1,7 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_html/flutter_html.dart';
-import 'package:we_find/model/I18NString.dart';
+import 'package:provider/provider.dart';
 import 'package:we_find/model/modelWrapped.dart';
+import 'package:we_find/providers/lang_provider.dart';
 
 class GroupPicker extends StatefulWidget {
   final List<GroupWrapped> _groups;
@@ -58,11 +59,14 @@ class _GroupPickerState extends State<GroupPicker> {
 
 class GroupDetails extends StatelessWidget {
   final GroupWrapped _group;
+
   const GroupDetails(this._group);
 
-  Column _buildGroupDetails(ThemeData themeData) {
-    Lang currentLang = Lang.DE;
-    Lang fallbackLang = Lang.EN;
+  Column _buildGroupDetails(BuildContext context) {
+    final ThemeData themeData = Theme.of(context);
+    // Access the language set by the user
+    final langProvider = Provider.of<LangProvider>(context);
+    final currentLang = langProvider.currentLang;
 
     List<Widget> view = [];
 
@@ -121,18 +125,18 @@ class GroupDetails extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final ThemeData themeData = Theme.of(context);
     return Container(
       margin: const EdgeInsets.all(15),
       padding: const EdgeInsets.all(15),
       //height: 1000,
-      child: _buildGroupDetails(themeData),
+      child: _buildGroupDetails(context),
     );
   }
 }
 
 class EventCalendar extends StatelessWidget {
   final ScheduleWrapped _schedule;
+
   const EventCalendar(this._schedule);
 
   Row _eventToWidget(EventWrapped event) {


### PR DESCRIPTION
Adds support for providers, the hard-coded `Lang` instances are changed in favour of the shared state retrieved from the provider. There are some inconsistencies in the way how the `*Wrapped` model objects get the `Lang` to be used, it should be standardized in a later issue.

Closes #25 